### PR TITLE
Allow overriding the token duration

### DIFF
--- a/cmd/eiam/assume_privileges.go
+++ b/cmd/eiam/assume_privileges.go
@@ -50,6 +50,10 @@ func newCmdAssumePrivileges() *cobra.Command {
 				return err
 			}
 
+			if err := options.CheckTokenDuration(apCmdConfig.TokenDuration); err != nil {
+				return err
+			}
+
 			if err := util.FormatReason(&apCmdConfig.Reason); err != nil {
 				return err
 			}
@@ -71,6 +75,7 @@ func newCmdAssumePrivileges() *cobra.Command {
 	options.AddServiceAccountEmailFlag(cmd.Flags(), &apCmdConfig.ServiceAccountEmail, true)
 	options.AddReasonFlag(cmd.Flags(), &apCmdConfig.Reason, true)
 	options.AddProjectFlag(cmd.Flags(), &apCmdConfig.Project, false)
+	options.AddTokenDurationFlag(cmd.Flags(), &apCmdConfig.TokenDuration, false)
 
 	return cmd
 }
@@ -84,7 +89,7 @@ func startPrivilegedSession() error {
 	}
 
 	util.Logger.Info("Fetching short-lived access token for ", apCmdConfig.ServiceAccountEmail)
-	accessToken, err := gcpclient.GenerateTemporaryAccessToken(apCmdConfig.ServiceAccountEmail, apCmdConfig.Reason)
+	accessToken, err := gcpclient.GenerateTemporaryAccessToken(apCmdConfig.ServiceAccountEmail, apCmdConfig.Reason, apCmdConfig.TokenDuration)
 	if err != nil {
 		return err
 	}

--- a/cmd/eiam/cloud_sql_proxy.go
+++ b/cmd/eiam/cloud_sql_proxy.go
@@ -62,6 +62,10 @@ func newCmdCloudSQLProxy() *cobra.Command {
 				return err
 			}
 
+			if err := options.CheckTokenDuration(cspCmdConfig.TokenDuration); err != nil {
+				return err
+			}
+
 			cloudSQLProxyCmdArgs = util.ExtractUnknownArgs(cmd.Flags(), os.Args)
 			if err := util.FormatReason(&cspCmdConfig.Reason); err != nil {
 				return err
@@ -85,6 +89,7 @@ func newCmdCloudSQLProxy() *cobra.Command {
 	options.AddServiceAccountEmailFlag(cmd.Flags(), &cspCmdConfig.ServiceAccountEmail, true)
 	options.AddReasonFlag(cmd.Flags(), &cspCmdConfig.Reason, true)
 	options.AddProjectFlag(cmd.Flags(), &cspCmdConfig.Project, false)
+	options.AddTokenDurationFlag(cmd.Flags(), &cspCmdConfig.TokenDuration, false)
 
 	return cmd
 }
@@ -98,7 +103,7 @@ func runCloudSQLProxyCommand() error {
 	}
 
 	util.Logger.Infof("Fetching access token for %s", cspCmdConfig.ServiceAccountEmail)
-	accessToken, err := gcpclient.GenerateTemporaryAccessToken(cspCmdConfig.ServiceAccountEmail, cspCmdConfig.Reason)
+	accessToken, err := gcpclient.GenerateTemporaryAccessToken(cspCmdConfig.ServiceAccountEmail, cspCmdConfig.Reason, cspCmdConfig.TokenDuration)
 	if err != nil {
 		return err
 	}

--- a/cmd/eiam/kubectl.go
+++ b/cmd/eiam/kubectl.go
@@ -58,6 +58,10 @@ func newCmdKubectl() *cobra.Command {
 				return err
 			}
 
+			if err := options.CheckTokenDuration(kubectlCmdConfig.TokenDuration); err != nil {
+				return err
+			}
+
 			kubectlCmdArgs = util.ExtractUnknownArgs(cmd.Flags(), os.Args)
 			if err := util.FormatReason(&kubectlCmdConfig.Reason); err != nil {
 				return err
@@ -81,6 +85,7 @@ func newCmdKubectl() *cobra.Command {
 	options.AddServiceAccountEmailFlag(cmd.Flags(), &kubectlCmdConfig.ServiceAccountEmail, true)
 	options.AddReasonFlag(cmd.Flags(), &kubectlCmdConfig.Reason, true)
 	options.AddProjectFlag(cmd.Flags(), &kubectlCmdConfig.Project, false)
+	options.AddTokenDurationFlag(cmd.Flags(), &kubectlCmdConfig.TokenDuration, false)
 
 	return cmd
 }
@@ -97,6 +102,7 @@ func runKubectlCommand() error {
 	accessToken, err := gcpclient.GenerateTemporaryAccessToken(
 		kubectlCmdConfig.ServiceAccountEmail,
 		kubectlCmdConfig.Reason,
+		kubectlCmdConfig.TokenDuration,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
10m is fine for some things, but other things need more time.

This change adds a flag to let the user extend the duration of the token
up to an hour.