### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ override.tf.json
 
 # Ignore local testing scripts
 scripts/
+
+# Ignore direnv
+.direnv
+
+# Ignore nix output
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667077288,
+        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1667125965,
+        "narHash": "sha256-z/OLvPwIhwdN9J+ED/0rPz/Wh/0sPuvczURwsiEENSQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "26eb67abc9a7370a51fcb86ece18eaf19ae9207f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Ephemeral IAM";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+     in {
+        packages.default = pkgs.buildGoModule rec {
+          pname = "ephemeral-iam";
+          version = "0.0.22";
+
+          src = ./.;
+
+          vendorSha256 = "sha256-iJe97gPFTVmiFbHNEqhrA+xqFyXO8kz7K69wm8IJ+AE=";
+
+          buildInputs = [ pkgs.makeWrapper ];
+          postInstall = ''
+            wrapProgram "$out/bin/ephemeral-iam" \
+              --prefix PATH : $out/bin:${pkgs.lib.makeBinPath [ pkgs.google-cloud-sdk ]}
+            ln -s $out/bin/ephemeral-iam $out/bin/eiam
+          '';
+
+          doCheck = false;
+        };
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [ go gopls ];
+        };
+      });
+}


### PR DESCRIPTION
This adds a Nix flake which make it easier to use this in other projects
and allows us to pin this to a specific nixpkgs revision which reduces
odds of breakage when a dependent repo wants to update its nixpkgs
revision.
