### PR TITLE
Skip adding access-token if no AuthProvider is provided.

### DIFF
--- a/internal/proxy/shell.go
+++ b/internal/proxy/shell.go
@@ -168,6 +168,10 @@ func writeCredsToKubeConfig(tmpKubeConfig *os.File, accessToken, expiry string) 
 
 	// There should only be one, this is an efficient way of getting it.
 	for _, authInfo := range config.AuthInfos {
+		if authInfo.AuthProvider == nil {
+			util.Logger.Infof("No authprovider on authInfo in config, skipping.")
+			continue	
+		}
 		// Write the service account's token to the temp kubeconfig.
 		authInfo.AuthProvider.Config["access-token"] = accessToken
 		authInfo.AuthProvider.Config["expiry"] = expiry


### PR DESCRIPTION
After we moved to use gke-gcloud-auth-plugin, e-iam has panicked because there is no AuthProvider on the AuthInfo object in the temp config. This PR skips writing the access token (and logs it) if no AuthProvider is found.

Tested by successfully getting an authorized shell and being able to run `terraform plan`.