### PR TITLE
Add flag to write kube config config.

### DIFF
--- a/cmd/eiam/cloud_sql_proxy.go
+++ b/cmd/eiam/cloud_sql_proxy.go
@@ -103,7 +103,10 @@ func runCloudSQLProxyCommand() error {
 	}
 
 	util.Logger.Infof("Fetching access token for %s", cspCmdConfig.ServiceAccountEmail)
-	accessToken, err := gcpclient.GenerateTemporaryAccessToken(cspCmdConfig.ServiceAccountEmail, cspCmdConfig.Reason, cspCmdConfig.TokenDuration)
+	accessToken, err := gcpclient.GenerateTemporaryAccessToken(
+		cspCmdConfig.ServiceAccountEmail,
+		cspCmdConfig.Reason,
+		cspCmdConfig.TokenDuration)
 	if err != nil {
 		return err
 	}

--- a/cmd/eiam/gcloud.go
+++ b/cmd/eiam/gcloud.go
@@ -62,8 +62,6 @@ func newCmdGcloud() *cobra.Command {
 				return err
 			}
 
-
-
 			if !options.YesOption {
 				util.Confirm(map[string]string{
 					"Project":         gcloudCmdConfig.Project,
@@ -101,15 +99,15 @@ func runGcloudCommand() error {
 	// There has to be a better way to do this...
 	util.Logger.Infof("Running: [gcloud %s]\n\n", strings.Join(gcloudCmdArgs, " "))
 
-    gcloudOpts := gcloudCmdArgs
-    positionalArgs := []string{}
-    for i, v := range gcloudCmdArgs {
-        if v == "--" {
-            gcloudOpts = gcloudCmdArgs[:i]
-            positionalArgs = gcloudCmdArgs[i:]
-            break
-        }
-    }
+	gcloudOpts := gcloudCmdArgs
+	positionalArgs := []string{}
+	for i, v := range gcloudCmdArgs {
+		if v == "--" {
+			gcloudOpts = gcloudCmdArgs[:i]
+			positionalArgs = gcloudCmdArgs[i:]
+			break
+		}
+	}
 
 	cmdArgs := append([]string(nil), gcloudOpts...)
 	cmdArgs = append(cmdArgs, "--impersonate-service-account", gcloudCmdConfig.ServiceAccountEmail, "--verbosity=error")

--- a/internal/gcpclient/iam.go
+++ b/internal/gcpclient/iam.go
@@ -41,7 +41,11 @@ const (
 )
 
 // GenerateTemporaryAccessToken generates short-lived credentials for the given service account.
-func GenerateTemporaryAccessToken(svcAcct, reason string, tokenDuration time.Duration) (*credentialspb.GenerateAccessTokenResponse, error) {
+func GenerateTemporaryAccessToken(
+	svcAcct,
+	reason string,
+	tokenDuration time.Duration,
+) (*credentialspb.GenerateAccessTokenResponse, error) {
 	client, err := ClientWithReason(reason)
 	if err != nil {
 		return nil, err

--- a/pkg/options/common.go
+++ b/pkg/options/common.go
@@ -36,7 +36,8 @@ const (
 
 // YesOption designates whether to prompt for confirmation or not.
 var (
-	YesOption = false
+	YesOption             = false
+	KubeConfigSetupOption = false
 )
 
 // Flag names and shorthands.
@@ -64,6 +65,9 @@ var (
 
 	// TokenDurationFlag sets the token duration for a command.
 	TokenDurationFlag = flagName{"duration", "d"}
+
+	// KubeSetupFlag sets the token duration for a command.
+	KubeConfigSetupFlag = flagName{"set-kube-config-envs", "k"}
 )
 
 type flagName struct {
@@ -87,6 +91,12 @@ type CmdConfig struct {
 // AddPersistentFlags add persistent flags to the root command.
 func AddPersistentFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&YesOption, YesFlag.Name, YesFlag.Shorthand, YesOption, "Assume 'yes' to all prompts")
+	fs.BoolVarP(
+		&KubeConfigSetupOption,
+		KubeConfigSetupFlag.Name,
+		KubeConfigSetupFlag.Shorthand,
+		KubeConfigSetupOption,
+		"Set kube config envvars")
 
 	currLogFmt := viper.GetString(appconfig.LoggingFormat)
 	fs.StringP(FormatFlag.Name, FormatFlag.Shorthand, currLogFmt, "Set the output of the current command")


### PR DESCRIPTION
Writing the kubeconfig can do weird stuff with CDK, so it's safer to put it behind a flag unless you actually want it. 

```
jamesaustin@Jamess-MBP ai-iac % USE_GKE_GCLOUD_AUTH_PLUGIN=True ephemeral-iam priv -p replit-ai-dev -s sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com -R terraform -d 1h -y -k
INFO    Fetching short-lived access token for sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com
INFO    Configuring gcloud to use auth proxy
INFO    Writing auth proxy logs to /Users/jamesaustin/Library/Application Support/ephemeral-iam/log/20230809145159_auth_proxy.log
INFO    Starting auth proxy. Privileged session will last until Wed, 09 Aug 2023 15:51:57 PDT
INFO    kubectl is now authenticated as sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com
INFO    No authprovider on authInfo in config, skipping.
WARNING Enter `exit` or press CTRL+D to quit privileged session

The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.

[sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com]
[eiam] > env | grep KUBE
KUBECONFIG=/Users/jamesaustin/Library/Application Support/ephemeral-iam/tmp_kube_config/2da47912-ddf4-48a7-9c6e-692896814a503390682135
KUBE_CONFIG_PATH=/Users/jamesaustin/Library/Application Support/ephemeral-iam/tmp_kube_config/2da47912-ddf4-48a7-9c6e-692896814a503390682135

[sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com]
[eiam] > exit
INFO    Stopping auth proxy and restoring gcloud config
jamesaustin@Jamess-MBP ai-iac % USE_GKE_GCLOUD_AUTH_PLUGIN=True ephemeral-iam priv -p replit-ai-dev -s sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com -R terraform -d 1h -y
INFO    Fetching short-lived access token for sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com
INFO    Configuring gcloud to use auth proxy
INFO    Writing auth proxy logs to /Users/jamesaustin/Library/Application Support/ephemeral-iam/log/20230809145217_auth_proxy.log
INFO    Starting auth proxy. Privileged session will last until Wed, 09 Aug 2023 15:52:16 PDT
WARNING Enter `exit` or press CTRL+D to quit privileged session

The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.

[sudo-replit-ai-dev@replit-ai-dev.iam.gserviceaccount.com]
[eiam] > env | grep KUBE

```

Tests pass locally, but looks like CI/CD is borked. Linting fails are all dependency related.