### PR TITLE
Update README.md with hint what to do when eiam crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,6 @@ Global Flags:
 ### Tutorial
 To better familiarize yourself with `ephemeral-iam` and how it works, you can
 follow [the tutorial provided in the documentation](docs/tutorial).
+
+### Known issuies
+If `eiam` crashes you might need to set `export USE_GKE_GCLOUD_AUTH_PLUGIN=False`


### PR DESCRIPTION
`export USE_GKE_GCLOUD_AUTH_PLUGIN=False` might be needed, because new kubectl versions use the plugin by default and eiam does not like it