### PR TITLE
flake: remove flake-utils, simplify

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,40 +1,40 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667077288,
-        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667125965,
-        "narHash": "sha256-z/OLvPwIhwdN9J+ED/0rPz/Wh/0sPuvczURwsiEENSQ=",
+        "lastModified": 1710827359,
+        "narHash": "sha256-/KY8hffTh9SN/tTcDn/FrEiYwTXnU8NKnr4D7/stmmA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26eb67abc9a7370a51fcb86ece18eaf19ae9207f",
+        "rev": "5710127d9693421e78cca4f74fac2db6d67162b1",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,35 +2,43 @@
   description = "Ephemeral IAM";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs = {
+    self,
+    nixpkgs,
+    systems
+  }: let
+    eachSystem = nixpkgs.lib.genAttrs (import systems);
+  in {
+    packages = eachSystem (system:
     let
       pkgs = nixpkgs.legacyPackages.${system};
-     in {
-        packages.default = pkgs.buildGoModule rec {
-          pname = "ephemeral-iam";
-          version = "0.0.22";
+    in
+    {
+      default  = pkgs.buildGoModule rec {
+        pname = "ephemeral-iam";
+        version = "0.0.22";
 
-          src = ./.;
+        src = ./.;
 
-          vendorSha256 = "sha256-iJe97gPFTVmiFbHNEqhrA+xqFyXO8kz7K69wm8IJ+AE=";
+        vendorHash = "sha256-iJe97gPFTVmiFbHNEqhrA+xqFyXO8kz7K69wm8IJ+AE=";
 
-          buildInputs = [ pkgs.makeWrapper ];
-          postInstall = ''
-            wrapProgram "$out/bin/ephemeral-iam" \
-              --prefix PATH : $out/bin:${pkgs.lib.makeBinPath [ pkgs.google-cloud-sdk ]}
-            ln -s $out/bin/ephemeral-iam $out/bin/eiam
-          '';
+        buildInputs = [ pkgs.makeWrapper ];
+        postInstall = ''
+          wrapProgram "$out/bin/ephemeral-iam" \
+          --prefix PATH : $out/bin:${pkgs.lib.makeBinPath [ pkgs.google-cloud-sdk ]}
+          ln -s $out/bin/ephemeral-iam $out/bin/eiam
+        '';
 
-          doCheck = false;
-        };
+        doCheck = false;
+      };
 
-        devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [ go gopls ];
-        };
-      });
+      devShell = pkgs.mkShell {
+        buildInputs = with pkgs; [ go gopls ];
+      };
+    });
+  };
 }


### PR DESCRIPTION
Why
===
* I noticed the iac devshell was using multiple copies of flake-utils.
* We don't really need flake-utils, let's use nix-systems instead

What changed
===
* Use nix-systems, restructure flake.nix
* Updated inputs

Test plan
====
* `nix build` still works
* devshell via direnv still works