### PR TITLE
Add regex anchors to fix regex sanitizing bypass

### DIFF
--- a/cmd/eiam/plugins.go
+++ b/cmd/eiam/plugins.go
@@ -91,7 +91,7 @@ func newCmdPluginsInstall() *cobra.Command {
 			with. See 'eiam plugins auth --help' for more details.
 		`),
 		Args: func(cmd *cobra.Command, args []string) error {
-			urlRegex := regexp.MustCompile(`github\.com/(?P<user>[[:alnum:]\-]+)/(?P<repo>[[:alnum:]\.\-_]+)`)
+			urlRegex := regexp.MustCompile(`^github\.com/(?P<user>[[:alnum:]\-]+)/(?P<repo>[[:alnum:]\.\-_]+)$`)
 			match := urlRegex.FindStringSubmatch(url)
 			if match == nil {
 				err := fmt.Errorf("%s is not a valid Github repo URL", url)


### PR DESCRIPTION
Why
===
* Code scanning noted this regex was missing an anchor to protect against sanitizing bypass or some CLI shenanigans. This is very low risk because these plugins are coming from the CLI, but let's fix it anyway.

What changed
===
* Add start and end of line anchors

Test plan
===
* CI passes


Original description
====

Potential fix for [https://github.com/replit/ephemeral-iam/security/code-scanning/1](https://github.com/replit/ephemeral-iam/security/code-scanning/1)

To fix the problem, we need to add anchors to the regular expression to ensure it matches the entire URL string. Specifically, we should add `^` at the beginning and `$` at the end of the regular expression. This will ensure that the regular expression only matches strings that start with `github.com/` and end with the specified user and repository format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
