### PR TITLE
[nix] fix vendorHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
           src = ./.;
 
-          vendorHash = "sha256-MA3ZDeXp+XvxMkUZ/OD4c7wSSQlPdJ1Ct3Vw+vN1ia8=";
+          vendorHash = "sha256-UWm+Nild+M7YRnPyiaZu8zcOGHcDAN4uDWbvK9WeKS0=";
 
           buildInputs = [ pkgs.makeWrapper ];
           postInstall = ''


### PR DESCRIPTION
Why
===
* We updated the source code but not the vendorHash so it doesn't build

What changed
===
* Clear the vendorhash, rebuild and repopulate

Test plan
===
* nix build works again